### PR TITLE
Fix packet sizes for pixel and tone

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,7 @@ Dependencies
 This driver depends on:
 
 * `Adafruit CircuitPython <https://github.com/adafruit/circuitpython>`_
+  **CircuitPython must be at least version 6.0.0.**
 
 Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading

--- a/adafruit_ble_adafruit/addressable_pixel_service.py
+++ b/adafruit_ble_adafruit/addressable_pixel_service.py
@@ -34,12 +34,12 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE_Adafruit.git"
 from collections import namedtuple
 import struct
 
+import _bleio
+
 from adafruit_ble.attributes import Attribute
 from adafruit_ble.characteristics import Characteristic, ComplexCharacteristic
 from adafruit_ble.characteristics.int import Uint8Characteristic, Uint16Characteristic
 from adafruit_ble_adafruit.adafruit_service import AdafruitService
-
-import _bleio
 
 PixelValues = namedtuple("PixelValues", ("start", "write_now", "data"),)
 """Namedtuple for pixel data and instructions.

--- a/adafruit_ble_adafruit/addressable_pixel_service.py
+++ b/adafruit_ble_adafruit/addressable_pixel_service.py
@@ -122,7 +122,7 @@ class AddressablePixelService(AdafruitService):
         different parts of ``_pixel_packet``.
         """
         buf = self._pixel_packet_buf
-        num_read = self._pixel_packet.readinto(buf) # pylint: disable=no-member
+        num_read = self._pixel_packet.readinto(buf)  # pylint: disable=no-member
         if num_read == 0:
             # No new values available
             return None

--- a/adafruit_ble_adafruit/tone_service.py
+++ b/adafruit_ble_adafruit/tone_service.py
@@ -39,6 +39,7 @@ from adafruit_ble_adafruit.adafruit_service import AdafruitService
 
 from _bleio import PacketBuffer
 
+
 class _TonePacket(ComplexCharacteristic):
     uuid = AdafruitService.adafruit_service_uuid(0xC01)
 

--- a/adafruit_ble_adafruit/tone_service.py
+++ b/adafruit_ble_adafruit/tone_service.py
@@ -33,11 +33,11 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE_Adafruit.git"
 
 import struct
 
+from _bleio import PacketBuffer
+
 from adafruit_ble.attributes import Attribute
 from adafruit_ble.characteristics import Characteristic, ComplexCharacteristic
 from adafruit_ble_adafruit.adafruit_service import AdafruitService
-
-from _bleio import PacketBuffer
 
 
 class _TonePacket(ComplexCharacteristic):

--- a/adafruit_ble_adafruit/tone_service.py
+++ b/adafruit_ble_adafruit/tone_service.py
@@ -33,12 +33,11 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE_Adafruit.git"
 
 import struct
 
-from _bleio import PacketBuffer
-
 from adafruit_ble.attributes import Attribute
 from adafruit_ble.characteristics import Characteristic, ComplexCharacteristic
 from adafruit_ble_adafruit.adafruit_service import AdafruitService
 
+from _bleio import PacketBuffer
 
 class _TonePacket(ComplexCharacteristic):
     uuid = AdafruitService.adafruit_service_uuid(0xC01)


### PR DESCRIPTION
- Buffer sizes for `AddressablePixelService` and `ToneService`.
- Added a missing characteristic for `AddressablePixelService`.
- Made some changes for sphinx and pylint reasons.

@caternuson I think you've been working some support issues related to this. The real issue is that this library will exercise some bugs that are in CircuitPython 5.3.x, and 6.0.0-alpha.something and later work better.