### PR TITLE
fix mic on Clue demo

### DIFF
--- a/examples/ble_adafruit_clue.py
+++ b/examples/ble_adafruit_clue.py
@@ -114,9 +114,12 @@ while True:
             clue._mic.record(  # pylint: disable=protected-access
                 mic_samples, len(mic_samples)
             )
+            # Need to create an array of the correct type, because ulab
+            # seems to get broadcasting of builtin Python types wrong.
+            offset = np.array([32768], dtype=np.uint16)
             # This subtraction yields unsigned values which are
             # reinterpreted as signed after passing.
-            mic_svc.sound_samples = mic_samples - 32768
+            mic_svc.sound_samples = mic_samples - offset
             mic_last_update = now_msecs
 
         neopixel_values = neopixel_svc.values


### PR DESCRIPTION
The numpy in ulab doesn't seem to convert the result types the
same way as regular numpy, so the result of the mic_samples
subtraction had dtype=float, which was too big for that
characteristic and caused an error once an app connected.